### PR TITLE
space before end of comment is not required

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var placeholders = {
 };
 
 function matchExpressions(contents) {
-  return contents.match(/<!--\s+include:([a-z]+)\(([^)]+)\)\s+-->/);
+  return contents.match(/<!--\s+include:([a-z]+)\(([^)]+)\)\s*-->/);
 }
 
 function replaceExtension(filename, type, options) {


### PR DESCRIPTION
And problem is if somebody generates html from jade and jade generate this comment without space before and of comment e.g.:

``` html
<!-- include:js(js/**/*.js)-->
```
