### PR TITLE
Add baseUrl option for setting results url prefix.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function injectFiles(file, options) {
 
   var contents = file.contents.toString();
   var cwd = options.cwd || path.dirname(file.path);
+  var baseUrl = options.baseUrl || '';
   var matches = matchExpressions(contents);
 
   while( matches ) {
@@ -56,7 +57,7 @@ function injectFiles(file, options) {
     if( placeholder && files && files.length > 0 ) {
 
       includes = files.map(function(filename) {
-        filename = replaceExtension(filename, type, options);
+        filename = baseUrl + replaceExtension(filename, type, options);
         return placeholder.split('%').join(filename);
       }).join('\n');
     }


### PR DESCRIPTION
Add useful `baseUrl` option like [grunt-include-source](https://github.com/jwvdiermen/grunt-include-source#optionsbaseurl) plugin has.
